### PR TITLE
Add Pulsar configuration management and analytics dashboard

### DIFF
--- a/ajax/like.php
+++ b/ajax/like.php
@@ -6,6 +6,12 @@ header('Content-Type: application/json');
 
 Session::checkLoginUser();
 
+$user_profile = $_SESSION['glpiactiveprofile']['id'] ?? 0;
+if (!PluginAgilizepulsarConfig::canLike($user_profile)) {
+    echo json_encode(['success' => false, 'message' => 'Sem permissão']);
+    exit;
+}
+
 if (!isset($_POST['action']) || !isset($_POST['ticket_id'])) {
     echo json_encode(['success' => false, 'message' => 'Parâmetros inválidos']);
     exit;

--- a/front/dashboard.php
+++ b/front/dashboard.php
@@ -1,0 +1,649 @@
+<?php
+
+include('../../../inc/includes.php');
+Session::checkLoginUser();
+
+$user_profile = $_SESSION['glpiactiveprofile']['id'] ?? 0;
+
+if (!PluginAgilizepulsarConfig::canView($user_profile)) {
+    Html::displayRightError();
+    exit;
+}
+
+$config = PluginAgilizepulsarConfig::getConfig();
+$menu_name = $config['menu_name'];
+$idea_category_id = (int)$config['idea_category_id'];
+$campaign_category_id = (int)$config['campaign_category_id'];
+
+$period = $_GET['period'] ?? 'year';
+$category_filter = $_GET['category'] ?? 'ideas';
+$start_date_param = $_GET['start_date'] ?? '';
+$end_date_param = $_GET['end_date'] ?? '';
+
+$allowed_periods = ['month', 'quarter', 'year', 'custom'];
+if (!in_array($period, $allowed_periods, true)) {
+    $period = 'year';
+}
+
+$allowed_categories = ['ideas', 'campaigns', 'all'];
+if (!in_array($category_filter, $allowed_categories, true)) {
+    $category_filter = 'ideas';
+}
+
+global $DB, $CFG_GLPI;
+
+$now = new DateTime();
+$now->setTime(23, 59, 59);
+$startDate = null;
+$endDate = clone $now;
+
+if ($period === 'custom') {
+    $startDate = $start_date_param ? DateTime::createFromFormat('Y-m-d', $start_date_param) : null;
+    if ($startDate instanceof DateTime) {
+        $startDate->setTime(0, 0, 0);
+    } else {
+        $start_date_param = '';
+        $startDate = null;
+    }
+
+    $endCandidate = $end_date_param ? DateTime::createFromFormat('Y-m-d', $end_date_param) : null;
+    if ($endCandidate instanceof DateTime) {
+        $endCandidate->setTime(23, 59, 59);
+        $endDate = $endCandidate;
+    } else {
+        $end_date_param = $endDate->format('Y-m-d');
+    }
+} else {
+    if ($period === 'month') {
+        $startDate = (clone $endDate)->modify('-1 month');
+    } elseif ($period === 'quarter') {
+        $startDate = (clone $endDate)->modify('-3 months');
+    } else {
+        $startDate = (clone $endDate)->modify('-1 year');
+        $period = 'year';
+    }
+    $startDate->setTime(0, 0, 0);
+    $start_date_param = $startDate->format('Y-m-d');
+    $end_date_param = $endDate->format('Y-m-d');
+}
+
+if ($startDate && $endDate && $startDate > $endDate) {
+    $tmp = clone $startDate;
+    $startDate = clone $endDate;
+    $startDate->setTime(0, 0, 0);
+    $endDate = $tmp;
+    $endDate->setTime(23, 59, 59);
+}
+
+$startDateStr = $startDate ? $startDate->format('Y-m-d H:i:s') : null;
+$endDateStr = $endDate ? $endDate->format('Y-m-d H:i:s') : null;
+
+$timeline_dataset_label = __('Ideias', 'agilizepulsar');
+switch ($category_filter) {
+    case 'campaigns':
+        $active_categories = [$campaign_category_id];
+        $top_likes_title = __('Top 10 Campanhas Mais Curtidas', 'agilizepulsar');
+        $top_views_title = __('Top 10 Campanhas Mais Visualizadas', 'agilizepulsar');
+        $status_chart_title = __('Campanhas por Status', 'agilizepulsar');
+        $timeline_title = __('Evolução de Campanhas', 'agilizepulsar');
+        $timeline_dataset_label = __('Campanhas', 'agilizepulsar');
+        break;
+    case 'all':
+        $active_categories = [$idea_category_id, $campaign_category_id];
+        $top_likes_title = __('Top 10 Registros Mais Curtidos', 'agilizepulsar');
+        $top_views_title = __('Top 10 Registros Mais Visualizados', 'agilizepulsar');
+        $status_chart_title = __('Registros por Status', 'agilizepulsar');
+        $timeline_title = __('Evolução de Registros', 'agilizepulsar');
+        $timeline_dataset_label = __('Registros', 'agilizepulsar');
+        break;
+    case 'ideas':
+    default:
+        $category_filter = 'ideas';
+        $active_categories = [$idea_category_id];
+        $top_likes_title = __('Top 10 Ideias Mais Curtidas', 'agilizepulsar');
+        $top_views_title = __('Top 10 Ideias Mais Visualizadas', 'agilizepulsar');
+        $status_chart_title = __('Ideias por Status', 'agilizepulsar');
+        $timeline_title = __('Evolução de Ideias', 'agilizepulsar');
+        $timeline_dataset_label = __('Ideias', 'agilizepulsar');
+        break;
+}
+
+$buildWhere = function (array $categoryIds, $alias = 't') use ($DB, $startDateStr, $endDateStr) {
+    if (empty($categoryIds)) {
+        return '1=0';
+    }
+
+    $categoryIds = array_map('intval', $categoryIds);
+    $parts = [];
+    $parts[] = sprintf('%s.itilcategories_id IN (%s)', $alias, implode(',', $categoryIds));
+
+    if ($startDateStr) {
+        $parts[] = sprintf("%s.date >= '%s'", $alias, $DB->escape($startDateStr));
+    }
+
+    if ($endDateStr) {
+        $parts[] = sprintf("%s.date <= '%s'", $alias, $DB->escape($endDateStr));
+    }
+
+    return implode(' AND ', $parts);
+};
+
+$countTickets = function (array $categoryIds, array $statuses = []) use ($DB, $buildWhere) {
+    if (empty($categoryIds)) {
+        return 0;
+    }
+
+    $where = $buildWhere($categoryIds, 't');
+    if (!empty($statuses)) {
+        $statuses = array_map('intval', $statuses);
+        $where .= ' AND t.status IN (' . implode(',', $statuses) . ')';
+    }
+
+    $sql = "SELECT COUNT(*) AS total FROM glpi_tickets t WHERE $where";
+    $result = $DB->query($sql);
+    if ($result) {
+        $row = $DB->fetchAssoc($result);
+        return (int)($row['total'] ?? 0);
+    }
+
+    return 0;
+};
+
+$total_ideas = $countTickets([$idea_category_id]);
+$total_campaigns = $countTickets([$campaign_category_id]);
+$ideas_approved = $countTickets([$idea_category_id], [Ticket::SOLVED]);
+$ideas_implemented = $countTickets([$idea_category_id], [Ticket::CLOSED]);
+
+$top_likes = [];
+if (!empty($active_categories)) {
+    $whereSql = $buildWhere($active_categories, 't');
+    $sql = "SELECT t.id, t.name, t.users_id_recipient, t.itilcategories_id, COUNT(l.id) AS likes_count
+            FROM glpi_tickets t
+            LEFT JOIN glpi_plugin_agilizepulsar_likes l ON t.id = l.tickets_id
+            WHERE $whereSql
+            GROUP BY t.id, t.name, t.users_id_recipient, t.itilcategories_id
+            ORDER BY likes_count DESC, t.name ASC
+            LIMIT 10";
+
+    $iterator = $DB->request($sql);
+    foreach ($iterator as $row) {
+        $userName = __('Não informado', 'agilizepulsar');
+        if (!empty($row['users_id_recipient'])) {
+            $user = new User();
+            if ($user->getFromDB($row['users_id_recipient'])) {
+                $userName = $user->getFriendlyName();
+            }
+        }
+        $link = 'idea.php?id=' . $row['id'];
+        if ((int)$row['itilcategories_id'] !== $idea_category_id) {
+            $link = rtrim($CFG_GLPI['url_base'] ?? '', '/') . '/front/ticket.form.php?id=' . $row['id'];
+        }
+        $top_likes[] = [
+            'id'     => $row['id'],
+            'name'   => $row['name'],
+            'author' => $userName,
+            'count'  => (int)$row['likes_count'],
+            'link'   => $link
+        ];
+    }
+}
+
+$top_views = [];
+if (!empty($active_categories)) {
+    $whereSql = $buildWhere($active_categories, 't');
+    $sql = "SELECT t.id, t.name, t.users_id_recipient, t.itilcategories_id, COUNT(DISTINCT v.users_id) AS views_count
+            FROM glpi_tickets t
+            LEFT JOIN glpi_plugin_agilizepulsar_views v ON t.id = v.tickets_id
+            WHERE $whereSql
+            GROUP BY t.id, t.name, t.users_id_recipient, t.itilcategories_id
+            ORDER BY views_count DESC, t.name ASC
+            LIMIT 10";
+
+    $iterator = $DB->request($sql);
+    foreach ($iterator as $row) {
+        $userName = __('Não informado', 'agilizepulsar');
+        if (!empty($row['users_id_recipient'])) {
+            $user = new User();
+            if ($user->getFromDB($row['users_id_recipient'])) {
+                $userName = $user->getFriendlyName();
+            }
+        }
+        $link = 'idea.php?id=' . $row['id'];
+        if ((int)$row['itilcategories_id'] !== $idea_category_id) {
+            $link = rtrim($CFG_GLPI['url_base'] ?? '', '/') . '/front/ticket.form.php?id=' . $row['id'];
+        }
+        $top_views[] = [
+            'id'     => $row['id'],
+            'name'   => $row['name'],
+            'author' => $userName,
+            'count'  => (int)$row['views_count'],
+            'link'   => $link
+        ];
+    }
+}
+
+$status_counts = [];
+if (!empty($active_categories)) {
+    $whereSql = $buildWhere($active_categories, 't');
+    $sql = "SELECT t.status, COUNT(*) AS total
+            FROM glpi_tickets t
+            WHERE $whereSql
+            GROUP BY t.status";
+
+    $iterator = $DB->request($sql);
+    foreach ($iterator as $row) {
+        $status_counts[(int)$row['status']] = (int)$row['total'];
+    }
+}
+
+$timeline_start = new DateTime('first day of this month');
+$timeline_start->modify('-11 months');
+$timeline_start->setTime(0, 0, 0);
+if ($startDate && $startDate > $timeline_start) {
+    $timeline_start = (clone $startDate)->modify('first day of this month');
+}
+
+$month_labels = [];
+$month_keys = [];
+$cursor = clone $timeline_start;
+for ($i = 0; $i < 12; $i++) {
+    $month_labels[] = $cursor->format('m/Y');
+    $month_keys[] = $cursor->format('Y-m');
+    $cursor->modify('+1 month');
+}
+
+$monthly_counts_map = [];
+if (!empty($active_categories)) {
+    $whereSql = $buildWhere($active_categories, 't');
+    $whereSql .= " AND t.date >= '" . $DB->escape($timeline_start->format('Y-m-d H:i:s')) . "'";
+    if ($endDateStr) {
+        $whereSql .= " AND t.date <= '" . $DB->escape($endDateStr) . "'";
+    }
+
+    $sql = "SELECT DATE_FORMAT(t.date, '%Y-%m') AS month_key, COUNT(*) AS total
+            FROM glpi_tickets t
+            WHERE $whereSql
+            GROUP BY month_key";
+
+    $iterator = $DB->request($sql);
+    foreach ($iterator as $row) {
+        $monthly_counts_map[$row['month_key']] = (int)$row['total'];
+    }
+}
+
+$monthly_counts = [];
+foreach ($month_keys as $key) {
+    $monthly_counts[] = $monthly_counts_map[$key] ?? 0;
+}
+
+$status_labels = [];
+$status_values = [];
+$status_colors = [];
+$color_palette = ['#0ea5e9', '#6366f1', '#10b981', '#f97316', '#f43f5e', '#a855f7', '#14b8a6', '#f59e0b'];
+$color_index = 0;
+foreach (Ticket::getAllStatusArray() as $status => $label) {
+    $status_labels[] = $label;
+    $status_values[] = $status_counts[$status] ?? 0;
+    $status_colors[] = $color_palette[$color_index % count($color_palette)];
+    $color_index++;
+}
+
+$card_data = [
+    ['label' => __('Total Ideias', 'agilizepulsar'), 'value' => $total_ideas, 'icon' => 'fa-lightbulb'],
+    ['label' => __('Total Campanhas', 'agilizepulsar'), 'value' => $total_campaigns, 'icon' => 'fa-flag'],
+    ['label' => __('Ideias Aprovadas', 'agilizepulsar'), 'value' => $ideas_approved, 'icon' => 'fa-circle-check'],
+    ['label' => __('Ideias Implementadas', 'agilizepulsar'), 'value' => $ideas_implemented, 'icon' => 'fa-screwdriver-wrench']
+];
+
+if (isset($_GET['export'])) {
+    $export = $_GET['export'];
+    if ($export === 'csv') {
+        header('Content-Type: text/csv; charset=UTF-8');
+        header('Content-Disposition: attachment; filename="pulsar_dashboard.csv"');
+        $output = fopen('php://output', 'w');
+        fputcsv($output, ['Indicador', 'Valor']);
+        foreach ($card_data as $card) {
+            fputcsv($output, [$card['label'], $card['value']]);
+        }
+        fputcsv($output, []);
+        fputcsv($output, ['Status', 'Quantidade']);
+        foreach ($status_labels as $index => $label) {
+            fputcsv($output, [$label, $status_values[$index]]);
+        }
+        fputcsv($output, []);
+        fputcsv($output, [$top_likes_title]);
+        fputcsv($output, ['Título', 'Autor', 'Curtidas']);
+        foreach ($top_likes as $item) {
+            fputcsv($output, [$item['name'], $item['author'], $item['count']]);
+        }
+        fputcsv($output, []);
+        fputcsv($output, [$top_views_title]);
+        fputcsv($output, ['Título', 'Autor', 'Visualizações']);
+        foreach ($top_views as $item) {
+            fputcsv($output, [$item['name'], $item['author'], $item['count']]);
+        }
+        fclose($output);
+        exit;
+    }
+
+    if ($export === 'pdf') {
+        if (file_exists(GLPI_ROOT . '/lib/tcpdf/tcpdf.php')) {
+            require_once GLPI_ROOT . '/lib/tcpdf/tcpdf.php';
+            $pdf = new TCPDF();
+            $pdf->SetCreator('GLPI');
+            $pdf->SetAuthor('Pulsar');
+            $pdf->SetTitle('Dashboard Pulsar');
+            $pdf->AddPage();
+            $html = '<h1>Dashboard Pulsar</h1>';
+            $html .= '<h2>Indicadores</h2><ul>';
+            foreach ($card_data as $card) {
+                $html .= '<li><strong>' . htmlspecialchars($card['label']) . ':</strong> ' . (int)$card['value'] . '</li>';
+            }
+            $html .= '</ul>';
+            $html .= '<h2>' . htmlspecialchars($status_chart_title) . '</h2><ul>';
+            foreach ($status_labels as $index => $label) {
+                $html .= '<li>' . htmlspecialchars($label) . ': ' . (int)$status_values[$index] . '</li>';
+            }
+            $html .= '</ul>';
+            $html .= '<h2>' . htmlspecialchars($top_likes_title) . '</h2><ol>';
+            foreach ($top_likes as $item) {
+                $html .= '<li>' . htmlspecialchars($item['name']) . ' – ' . htmlspecialchars($item['author']) . ' (' . (int)$item['count'] . ')</li>';
+            }
+            $html .= '</ol>';
+            $html .= '<h2>' . htmlspecialchars($top_views_title) . '</h2><ol>';
+            foreach ($top_views as $item) {
+                $html .= '<li>' . htmlspecialchars($item['name']) . ' – ' . htmlspecialchars($item['author']) . ' (' . (int)$item['count'] . ')</li>';
+            }
+            $html .= '</ol>';
+            $pdf->writeHTML($html, true, false, true, false, '');
+            $pdf->Output('pulsar_dashboard.pdf', 'D');
+            exit;
+        }
+
+        header('Content-Type: text/plain; charset=UTF-8');
+        echo 'Biblioteca TCPDF não encontrada.';
+        exit;
+    }
+}
+
+$title = sprintf(__('%s – Dashboard', 'agilizepulsar'), $menu_name);
+if (Session::getCurrentInterface() == "helpdesk") {
+   Html::helpHeader($title, '', 'helpdesk', 'management');
+} else {
+   Html::header($title, $_SERVER['PHP_SELF'], 'management', 'pulsar');
+}
+
+$can_admin = PluginAgilizepulsarConfig::canAdmin($user_profile);
+
+$export_params = [
+    'period' => $period,
+    'category' => $category_filter
+];
+if ($period === 'custom') {
+    $export_params['start_date'] = $start_date_param;
+    $export_params['end_date'] = $end_date_param;
+}
+$pdf_link = 'dashboard.php?' . http_build_query($export_params + ['export' => 'pdf']);
+$csv_link = 'dashboard.php?' . http_build_query($export_params + ['export' => 'csv']);
+?>
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+<div id="pulsar-demo" class="pulsar-wrap">
+
+  <section class="pulsar-hero card-u">
+    <div class="hero-left">
+      <h1><?php echo htmlspecialchars($menu_name); ?></h1>
+      <p class="pulsar-muted">Acompanhe indicadores, rankings e a evolução das ideias.</p>
+    </div>
+    <div class="pulsar-actions">
+      <a href="feed.php" class="btn-u ghost"><i class="fa-solid fa-arrow-left"></i> Voltar</a>
+    </div>
+  </section>
+
+  <nav class="pulsar-topnav card-u" aria-label="Navegação do Pulsar">
+    <a class="topnav-item" href="feed.php">
+      <i class="fa-solid fa-bolt"></i>
+      <span>Feed</span>
+    </a>
+    <a class="topnav-item" href="my_ideas.php">
+      <i class="fa-solid fa-lightbulb"></i>
+      <span>Minhas Ideias</span>
+    </a>
+    <a class="topnav-item is-active" href="dashboard.php">
+      <i class="fa-solid fa-chart-bar"></i>
+      <span>Dashboard</span>
+    </a>
+    <?php if ($can_admin): ?>
+    <a class="topnav-item" href="settings.php">
+      <i class="fa-solid fa-gear"></i>
+      <span>Configurações</span>
+    </a>
+    <?php endif; ?>
+  </nav>
+
+  <section class="card-u dashboard-filters">
+    <form method="get" class="filters-form">
+      <div class="filter-group">
+        <label for="period-select">Período</label>
+        <select id="period-select" name="period">
+          <option value="month" <?php echo $period === 'month' ? 'selected' : ''; ?>>Último mês</option>
+          <option value="quarter" <?php echo $period === 'quarter' ? 'selected' : ''; ?>>Último trimestre</option>
+          <option value="year" <?php echo $period === 'year' ? 'selected' : ''; ?>>Último ano</option>
+          <option value="custom" <?php echo $period === 'custom' ? 'selected' : ''; ?>>Personalizado</option>
+        </select>
+      </div>
+      <div class="filter-group">
+        <label for="category-select">Categoria</label>
+        <select id="category-select" name="category">
+          <option value="ideas" <?php echo $category_filter === 'ideas' ? 'selected' : ''; ?>>Ideias</option>
+          <option value="campaigns" <?php echo $category_filter === 'campaigns' ? 'selected' : ''; ?>>Campanhas</option>
+          <option value="all" <?php echo $category_filter === 'all' ? 'selected' : ''; ?>>Todas</option>
+        </select>
+      </div>
+      <div class="filter-group custom-dates" <?php echo $period === 'custom' ? '' : 'style="display:none"'; ?>>
+        <label>Data inicial</label>
+        <input type="date" name="start_date" value="<?php echo htmlspecialchars($start_date_param); ?>">
+      </div>
+      <div class="filter-group custom-dates" <?php echo $period === 'custom' ? '' : 'style="display:none"'; ?>>
+        <label>Data final</label>
+        <input type="date" name="end_date" value="<?php echo htmlspecialchars($end_date_param); ?>">
+      </div>
+      <div class="filter-actions">
+        <button type="submit" class="btn-u primary"><i class="fa-solid fa-filter"></i> Aplicar</button>
+      </div>
+    </form>
+    <div class="export-actions">
+      <a href="<?php echo htmlspecialchars($pdf_link); ?>" class="btn-u ghost"><i class="fa-solid fa-file-pdf"></i> Exportar PDF</a>
+      <a href="<?php echo htmlspecialchars($csv_link); ?>" class="btn-u ghost"><i class="fa-solid fa-file-csv"></i> Exportar CSV</a>
+    </div>
+  </section>
+
+  <section class="card-grid">
+    <?php foreach ($card_data as $card): ?>
+    <article class="card-u dashboard-card">
+      <div class="card-icon"><i class="fa-solid <?php echo htmlspecialchars($card['icon']); ?>"></i></div>
+      <div class="card-info">
+        <span class="card-value"><?php echo (int)$card['value']; ?></span>
+        <span class="card-label"><?php echo htmlspecialchars($card['label']); ?></span>
+      </div>
+    </article>
+    <?php endforeach; ?>
+  </section>
+
+  <div class="dashboard-grid">
+    <section class="card-u">
+      <h2><i class="fa-solid fa-heart"></i> <?php echo htmlspecialchars($top_likes_title); ?></h2>
+      <table class="pulsar-table">
+        <thead>
+          <tr>
+            <th>Título</th>
+            <th>Autor</th>
+            <th>Curtidas</th>
+            <th>Link</th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php if (count($top_likes) === 0): ?>
+            <tr><td colspan="4" class="empty-cell">Nenhum registro encontrado</td></tr>
+          <?php else: ?>
+            <?php foreach ($top_likes as $item): ?>
+            <tr>
+              <td><?php echo htmlspecialchars($item['name']); ?></td>
+              <td><?php echo htmlspecialchars($item['author']); ?></td>
+              <td><?php echo (int)$item['count']; ?></td>
+              <td><a href="<?php echo htmlspecialchars($item['link']); ?>" class="link-inline"><i class="fa-solid fa-arrow-up-right-from-square"></i></a></td>
+            </tr>
+            <?php endforeach; ?>
+          <?php endif; ?>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card-u">
+      <h2><i class="fa-solid fa-eye"></i> <?php echo htmlspecialchars($top_views_title); ?></h2>
+      <table class="pulsar-table">
+        <thead>
+          <tr>
+            <th>Título</th>
+            <th>Autor</th>
+            <th>Visualizações</th>
+            <th>Link</th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php if (count($top_views) === 0): ?>
+            <tr><td colspan="4" class="empty-cell">Nenhum registro encontrado</td></tr>
+          <?php else: ?>
+            <?php foreach ($top_views as $item): ?>
+            <tr>
+              <td><?php echo htmlspecialchars($item['name']); ?></td>
+              <td><?php echo htmlspecialchars($item['author']); ?></td>
+              <td><?php echo (int)$item['count']; ?></td>
+              <td><a href="<?php echo htmlspecialchars($item['link']); ?>" class="link-inline"><i class="fa-solid fa-arrow-up-right-from-square"></i></a></td>
+            </tr>
+            <?php endforeach; ?>
+          <?php endif; ?>
+        </tbody>
+      </table>
+    </section>
+  </div>
+
+  <div class="dashboard-grid">
+    <section class="card-u">
+      <h2><i class="fa-solid fa-chart-pie"></i> <?php echo htmlspecialchars($status_chart_title); ?></h2>
+      <canvas id="statusChart" height="240"></canvas>
+    </section>
+
+    <section class="card-u">
+      <h2><i class="fa-solid fa-chart-line"></i> <?php echo htmlspecialchars($timeline_title); ?></h2>
+      <canvas id="timelineChart" height="240"></canvas>
+    </section>
+  </div>
+</div>
+
+<script>
+  const periodSelect = document.getElementById('period-select');
+  const customFields = document.querySelectorAll('.custom-dates');
+
+  function toggleCustomDates() {
+    const isCustom = periodSelect.value === 'custom';
+    customFields.forEach(field => {
+      field.style.display = isCustom ? '' : 'none';
+    });
+  }
+
+  periodSelect.addEventListener('change', toggleCustomDates);
+  toggleCustomDates();
+
+  const statusCtx = document.getElementById('statusChart');
+  const statusChart = new Chart(statusCtx, {
+    type: 'pie',
+    data: {
+      labels: <?php echo json_encode($status_labels); ?>,
+      datasets: [{
+        data: <?php echo json_encode($status_values); ?>,
+        backgroundColor: <?php echo json_encode($status_colors); ?>
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: {
+        legend: {position: 'bottom'}
+      }
+    }
+  });
+
+  const timelineCtx = document.getElementById('timelineChart');
+  const timelineChart = new Chart(timelineCtx, {
+    type: 'line',
+    data: {
+      labels: <?php echo json_encode($month_labels); ?>,
+      datasets: [{
+        label: '<?php echo addslashes($timeline_dataset_label); ?>',
+        data: <?php echo json_encode($monthly_counts); ?>,
+        borderColor: '#00995d',
+        backgroundColor: 'rgba(0, 153, 93, 0.15)',
+        tension: 0.3,
+        fill: true
+      }]
+    },
+    options: {
+      responsive: true,
+      scales: {
+        y: {
+          beginAtZero: true,
+          ticks: {
+            precision: 0
+          }
+        }
+      }
+    }
+  });
+</script>
+
+<style>
+  .pulsar-wrap *{box-sizing:border-box;margin:0;padding:0}
+  .pulsar-muted{color:#667085}
+  .pulsar-wrap{padding:16px}
+  :root{
+    --u-primary:#00995d;--u-primary-hover:#008552;--u-border:#d1d5db;
+    --u-chip:#e1e1e1;--u-dark:#004e4c;--u-success:#10b981;
+  }
+  .card-u{background:#fff;border:1px solid var(--u-border);border-radius:12px;padding:16px;box-shadow:0 1px 2px rgba(0,0,0,.05);margin-bottom:16px}
+  .pulsar-hero{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:16px;background:linear-gradient(135deg,#f7f7f7 0%,#eef3fb 100%);padding:20px}
+  .pulsar-hero h1{margin:0 0 6px 0;font-size:26px;color:var(--u-dark)}
+  .pulsar-actions{display:flex;gap:12px;flex-wrap:wrap}
+  .btn-u{border:0;border-radius:10px;padding:10px 16px;font-weight:600;cursor:pointer;transition:all .2s;text-decoration:none;display:inline-flex;align-items:center;gap:8px;}
+  .btn-u.primary{background:var(--u-primary);color:#fff}
+  .btn-u.primary:hover{background:var(--u-primary-hover);transform:translateY(-1px);box-shadow:0 2px 4px rgba(0,0,0,.1)}
+  .btn-u.ghost{background:#fff;border:1px solid var(--u-border)}
+  .btn-u.ghost:hover{background:var(--u-chip);border-color:var(--u-primary)}
+  .pulsar-topnav{display:flex;gap:8px;align-items:center;margin-bottom:16px;background:linear-gradient(180deg,#fff,#fbfcff);padding:12px 16px}
+  .topnav-item{display:flex;align-items:center;gap:8px;padding:10px 12px;border-radius:10px;color:#1f2933;text-decoration:none;font-weight:600}
+  .topnav-item.is-active,.topnav-item:hover{background:rgba(0,153,93,.12);color:#00995d}
+  .dashboard-filters{display:flex;flex-wrap:wrap;gap:16px;justify-content:space-between;align-items:flex-end}
+  .filters-form{display:flex;flex-wrap:wrap;gap:16px;align-items:flex-end}
+  .filter-group{display:flex;flex-direction:column;gap:8px;min-width:160px}
+  .filter-group label{font-weight:600;color:#1f2933}
+  .filter-group select,.filter-group input{border:1px solid var(--u-border);border-radius:8px;padding:10px;font-size:1rem}
+  .filter-actions{display:flex;align-items:flex-end}
+  .export-actions{display:flex;gap:12px;flex-wrap:wrap}
+  .card-grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin-bottom:16px}
+  .dashboard-card{display:flex;align-items:center;gap:16px}
+  .card-icon{width:56px;height:56px;border-radius:16px;background:rgba(0,153,93,.12);display:flex;align-items:center;justify-content:center;color:#00995d;font-size:24px}
+  .card-info{display:flex;flex-direction:column}
+  .card-value{font-size:26px;font-weight:700;color:#1f2933}
+  .card-label{color:#667085;font-size:0.95rem}
+  .dashboard-grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));margin-bottom:16px}
+  .pulsar-table{width:100%;border-collapse:collapse;margin-top:12px}
+  .pulsar-table th,.pulsar-table td{border-bottom:1px solid var(--u-border);padding:10px;text-align:left;font-size:0.95rem}
+  .pulsar-table th{color:#1f2933;font-weight:600;background:#f8fafc}
+  .pulsar-table tbody tr:hover{background:#f3f4f6}
+  .empty-cell{text-align:center;color:#9ca3af;font-style:italic}
+  .link-inline{color:#00995d;text-decoration:none}
+  .link-inline:hover{text-decoration:underline}
+</style>
+<?php
+Html::footer();

--- a/front/feed.php
+++ b/front/feed.php
@@ -3,7 +3,17 @@
 include('../../../inc/includes.php');
 Session::checkLoginUser();
 
-$title = __('Pulsar – Feed');
+$user_profile = $_SESSION['glpiactiveprofile']['id'] ?? 0;
+
+if (!PluginAgilizepulsarConfig::canView($user_profile)) {
+    Html::displayRightError();
+    exit;
+}
+
+$config = PluginAgilizepulsarConfig::getConfig();
+$menu_name = $config['menu_name'];
+
+$title = sprintf(__('%s – Feed', 'agilizepulsar'), $menu_name);
 if (Session::getCurrentInterface() == "helpdesk") {
    Html::helpHeader($title, '', 'helpdesk', 'management');
 } else {
@@ -14,6 +24,7 @@ $campaigns = PluginAgilizepulsarTicket::getCampaigns(['is_active' => true]);
 $ideas = PluginAgilizepulsarTicket::getIdeas();
 $ideas = array_slice($ideas, 0, 3);
 $ranking = PluginAgilizepulsarUserPoints::getRanking('total', 4);
+$can_admin = PluginAgilizepulsarConfig::canAdmin($user_profile);
 ?>
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
@@ -22,7 +33,7 @@ $ranking = PluginAgilizepulsarUserPoints::getRanking('total', 4);
 
   <section class="pulsar-hero card-u">
     <div class="hero-left">
-      <h1>Pulsar</h1>
+      <h1><?php echo htmlspecialchars($menu_name); ?></h1>
       <p class="pulsar-muted">Acompanhe campanhas ativas, engaje o time e transforme ideias em resultado.</p>
     </div>
     <div class="pulsar-actions">
@@ -43,10 +54,12 @@ $ranking = PluginAgilizepulsarUserPoints::getRanking('total', 4);
       <i class="fa-solid fa-chart-bar"></i>
       <span>Dashboard</span>
     </a>    
+    <?php if ($can_admin): ?>
     <a class="topnav-item" href="settings.php">
       <i class="fa-solid fa-gear"></i>
       <span>Configurações</span>
     </a>
+    <?php endif; ?>
   </nav>
 
   <div class="pulsar-search">

--- a/front/idea.php
+++ b/front/idea.php
@@ -3,6 +3,16 @@
 include('../../../inc/includes.php');
 Session::checkLoginUser();
 
+$user_profile = $_SESSION['glpiactiveprofile']['id'] ?? 0;
+
+if (!PluginAgilizepulsarConfig::canView($user_profile)) {
+    Html::displayRightError();
+    exit;
+}
+
+$config = PluginAgilizepulsarConfig::getConfig();
+$menu_name = $config['menu_name'];
+
 $tickets_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 
 if (!PluginAgilizepulsarTicket::isIdea($tickets_id)) {
@@ -14,18 +24,23 @@ if (!$ticket->getFromDB($tickets_id)) {
     Html::displayErrorAndDie(__('Item not found'));
 }
 
+PluginAgilizepulsarView::addView($tickets_id, Session::getLoginUserID());
+
 $idea = PluginAgilizepulsarTicket::enrichTicketData($ticket->fields);
 $form_answers = PluginAgilizepulsarTicket::getFormAnswers($tickets_id);
 $coauthors = PluginAgilizepulsarTicket::getCoauthors($tickets_id);
 $comments = PluginAgilizepulsarComment::getByTicket($tickets_id);
 $approvals = PluginAgilizepulsarApproval::getByTicket($tickets_id);
 
-$title = __('Pulsar – ') . $idea['name'];
+$title = sprintf(__('%s – %s', 'agilizepulsar'), $menu_name, $idea['name']);
 if (Session::getCurrentInterface() == "helpdesk") {
    Html::helpHeader($title, '', 'helpdesk', 'management');
 } else {
    Html::header($title, $_SERVER['PHP_SELF'], 'management', 'pulsar');
 }
+
+$can_admin = PluginAgilizepulsarConfig::canAdmin($user_profile);
+$can_like = PluginAgilizepulsarConfig::canLike($user_profile);
 
 $user = new User();
 $user->getFromDB($idea['users_id_recipient']);
@@ -37,7 +52,7 @@ $user->getFromDB($idea['users_id_recipient']);
 
   <section class="pulsar-hero card-u">
     <div class="hero-left">
-      <h1>Pulsar</h1>
+      <h1><?php echo htmlspecialchars($menu_name); ?></h1>
       <p class="pulsar-muted">Detalhes da Ideia</p>
     </div>
     <div class="pulsar-actions">
@@ -58,9 +73,11 @@ $user->getFromDB($idea['users_id_recipient']);
     <a class="topnav-item" href="dashboard.php">
       <i class="fa-solid fa-chart-bar"></i><span>Dashboard</span>
     </a>
+    <?php if ($can_admin): ?>
     <a class="topnav-item" href="settings.php">
       <i class="fa-solid fa-gear"></i><span>Configurações</span>
     </a>
+    <?php endif; ?>
   </nav>
 
   <div class="idea-detail-container">
@@ -82,6 +99,7 @@ $user->getFromDB($idea['users_id_recipient']);
           <div class="idea-stats">
             <span class="stat-item"><i class="fa-solid fa-heart"></i> <span id="likes-count"><?php echo $idea['likes_count']; ?></span></span>
             <span class="stat-item"><i class="fa-solid fa-comment"></i> <?php echo $idea['comments_count']; ?></span>
+            <span class="stat-item"><i class="fa-solid fa-eye"></i> <?php echo $idea['views_count']; ?></span>
           </div>
         </div>
       </div>
@@ -163,7 +181,11 @@ $user->getFromDB($idea['users_id_recipient']);
             </div>
 
             <div class="idea-actions">
-              <button class="btn-u primary full-width" id="btn-like" data-ticket="<?php echo $tickets_id; ?>" data-liked="<?php echo $idea['has_liked'] ? '1' : '0'; ?>">
+              <div class="stat-item">
+                <i class="fa-solid fa-eye"></i>
+                <?php echo $idea['views_count']; ?> visualizações
+              </div>
+              <button class="btn-u primary full-width" id="btn-like" data-ticket="<?php echo $tickets_id; ?>" data-liked="<?php echo $idea['has_liked'] ? '1' : '0'; ?>" data-can-like="<?php echo $can_like ? '1' : '0'; ?>" <?php echo $can_like ? '' : 'disabled'; ?>>
                 <i class="fa-solid fa-heart"></i> <?php echo $idea['has_liked'] ? 'Descurtir' : 'Curtir'; ?>
               </button>
               <button class="btn-u ghost full-width" onclick="navigator.clipboard.writeText(window.location.href)">
@@ -194,6 +216,7 @@ $user->getFromDB($idea['users_id_recipient']);
   .btn-u.primary:hover{background:var(--u-primary-hover);transform:translateY(-1px);box-shadow:0 2px 4px rgba(0,0,0,.1)}
   .btn-u.ghost{background:#fff;border:1px solid var(--u-border)}
   .btn-u.ghost:hover{background:var(--u-chip);border-color:var(--u-primary)}
+  .btn-u[disabled]{opacity:.6;cursor:not-allowed}
   .btn-u.small{padding:8px 12px;font-size:.875rem}
   .full-width{width:100%}
 
@@ -245,7 +268,7 @@ $user->getFromDB($idea['users_id_recipient']);
   .idea-actions{display:flex;flex-direction:column;gap:8px;margin-top:12px;}
 </style>
 
-<script src="<?php echo $CFG_GLPI['root_doc']; ?>/plugins/agilizepulsar/js/pulsar.js"></script>
+<script src="<?php echo htmlspecialchars($CFG_GLPI['root_doc']); ?>/plugins/agilizepulsar/js/pulsar.js"></script>
 
 <script>
 (function() {
@@ -253,16 +276,21 @@ $user->getFromDB($idea['users_id_recipient']);
   const likeCount = document.getElementById('likes-count');
   const ticketId = btnLike.dataset.ticket;
   let liked = btnLike.dataset.liked === '1';
+  const canLike = btnLike.dataset.canLike === '1';
 
-  btnLike.addEventListener('click', function() {
-    PulsarLike.toggle(ticketId, function(response) {
-      if (response.success) {
-        liked = response.liked;
-        likeCount.textContent = response.count;
-        btnLike.innerHTML = liked ? '<i class="fa-solid fa-heart"></i> Descurtir' : '<i class="fa-solid fa-heart"></i> Curtir';
-      }
+  if (canLike) {
+    btnLike.addEventListener('click', function() {
+      PulsarLike.toggle(ticketId, function(response) {
+        if (response.success) {
+          liked = response.liked;
+          likeCount.textContent = response.count;
+          btnLike.innerHTML = liked ? '<i class="fa-solid fa-heart"></i> Descurtir' : '<i class="fa-solid fa-heart"></i> Curtir';
+        }
+      });
     });
-  });
+  } else {
+    btnLike.setAttribute('title', 'Sem permissão para curtir');
+  }
 
   const btnComment = document.getElementById('btn-add-comment');
   const textarea = document.getElementById('comment-text');

--- a/front/ideas_all.php
+++ b/front/ideas_all.php
@@ -3,7 +3,17 @@
 include('../../../inc/includes.php');
 Session::checkLoginUser();
 
-$title = __('Pulsar – Todas as Ideias');
+$user_profile = $_SESSION['glpiactiveprofile']['id'] ?? 0;
+
+if (!PluginAgilizepulsarConfig::canView($user_profile)) {
+    Html::displayRightError();
+    exit;
+}
+
+$config = PluginAgilizepulsarConfig::getConfig();
+$menu_name = $config['menu_name'];
+
+$title = sprintf(__('%s – Todas as Ideias', 'agilizepulsar'), $menu_name);
 if (Session::getCurrentInterface() == "helpdesk") {
    Html::helpHeader($title, '', 'helpdesk', 'management');
 } else {
@@ -15,6 +25,7 @@ $ideas = PluginAgilizepulsarTicket::getIdeas();
 
 // Buscar campanhas para o filtro
 $campaigns = PluginAgilizepulsarTicket::getCampaigns();
+$can_admin = PluginAgilizepulsarConfig::canAdmin($user_profile);
 ?>
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
@@ -23,7 +34,7 @@ $campaigns = PluginAgilizepulsarTicket::getCampaigns();
 
   <section class="pulsar-hero card-u">
     <div class="hero-left">
-      <h1>Pulsar</h1>
+      <h1><?php echo htmlspecialchars($menu_name); ?></h1>
       <p class="pulsar-muted">Explore todas as ideias enviadas pela comunidade.</p>
     </div>
     <div class="pulsar-actions">
@@ -45,10 +56,12 @@ $campaigns = PluginAgilizepulsarTicket::getCampaigns();
       <i class="fa-solid fa-chart-bar"></i>
       <span>Dashboard</span>
     </a>    
+    <?php if ($can_admin): ?>
     <a class="topnav-item" href="settings.php">
       <i class="fa-solid fa-gear"></i>
       <span>Configurações</span>
     </a>
+    <?php endif; ?>
   </nav>
 
   <div class="pulsar-filters-container card-u">

--- a/front/my_ideas.php
+++ b/front/my_ideas.php
@@ -3,15 +3,26 @@
 include('../../../inc/includes.php');
 Session::checkLoginUser();
 
+$user_profile = $_SESSION['glpiactiveprofile']['id'] ?? 0;
+
+if (!PluginAgilizepulsarConfig::canView($user_profile)) {
+    Html::displayRightError();
+    exit;
+}
+
+$config = PluginAgilizepulsarConfig::getConfig();
+$menu_name = $config['menu_name'];
+
 $user_id = Session::getLoginUserID();
 $ideas = PluginAgilizepulsarTicket::getIdeas(['users_id' => $user_id]);
 
-$title = __('Pulsar – Minhas Ideias');
+$title = sprintf(__('%s – Minhas Ideias', 'agilizepulsar'), $menu_name);
 if (Session::getCurrentInterface() == "helpdesk") {
    Html::helpHeader($title, '', 'helpdesk', 'management');
 } else {
    Html::header($title, $_SERVER['PHP_SELF'], 'management', 'pulsar');
 }
+$can_admin = PluginAgilizepulsarConfig::canAdmin($user_profile);
 ?>
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
@@ -20,7 +31,7 @@ if (Session::getCurrentInterface() == "helpdesk") {
 
   <section class="pulsar-hero card-u">
     <div class="hero-left">
-      <h1>Pulsar</h1>
+      <h1><?php echo htmlspecialchars($menu_name); ?></h1>
       <p class="pulsar-muted">Acompanhe suas contribuições e o status de cada ideia.</p>
     </div>
     <div class="pulsar-actions">
@@ -41,10 +52,12 @@ if (Session::getCurrentInterface() == "helpdesk") {
       <i class="fa-solid fa-chart-bar"></i>
       <span>Dashboard</span>
     </a>    
+    <?php if ($can_admin): ?>
     <a class="topnav-item" href="settings.php">
       <i class="fa-solid fa-gear"></i>
       <span>Configurações</span>
     </a>
+    <?php endif; ?>
   </nav>
 
   <div class="pulsar-filters card-u">

--- a/front/settings.php
+++ b/front/settings.php
@@ -1,0 +1,231 @@
+<?php
+
+include('../../../inc/includes.php');
+Session::checkLoginUser();
+
+$user_profile = $_SESSION['glpiactiveprofile']['id'] ?? 0;
+
+if (!PluginAgilizepulsarConfig::canView($user_profile)) {
+    Html::displayRightError();
+    exit;
+}
+
+if (!PluginAgilizepulsarConfig::canAdmin($user_profile)) {
+    Html::displayRightError();
+    exit;
+}
+
+$config = PluginAgilizepulsarConfig::getConfig();
+$menu_name = $config['menu_name'];
+
+$view_profiles  = json_decode($config['view_profile_ids'] ?? '[]', true) ?: [];
+$like_profiles  = json_decode($config['like_profile_ids'] ?? '[]', true) ?: [];
+$admin_profiles = json_decode($config['admin_profile_ids'] ?? '[]', true) ?: [];
+
+$campaign_category_id = (int)$config['campaign_category_id'];
+$idea_category_id     = (int)$config['idea_category_id'];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (method_exists('Session', 'checkCSRF')) {
+        Session::checkCSRF();
+    }
+
+    $menu_name_post = trim($_POST['menu_name'] ?? '');
+    $campaign_post  = (int)($_POST['campaign_category_id'] ?? 0);
+    $idea_post      = (int)($_POST['idea_category_id'] ?? 0);
+    $view_post      = isset($_POST['view_profile_ids']) ? array_map('intval', (array)$_POST['view_profile_ids']) : [];
+    $like_post      = isset($_POST['like_profile_ids']) ? array_map('intval', (array)$_POST['like_profile_ids']) : [];
+    $admin_post     = isset($_POST['admin_profile_ids']) ? array_map('intval', (array)$_POST['admin_profile_ids']) : [];
+
+    $data = [
+        'menu_name'            => $menu_name_post !== '' ? $menu_name_post : 'Pulsar',
+        'campaign_category_id' => $campaign_post ?: $campaign_category_id,
+        'idea_category_id'     => $idea_post ?: $idea_category_id,
+        'view_profile_ids'     => json_encode(array_values(array_unique($view_post))),
+        'like_profile_ids'     => json_encode(array_values(array_unique($like_post))),
+        'admin_profile_ids'    => json_encode(array_values(array_unique($admin_post)))
+    ];
+
+    if (PluginAgilizepulsarConfig::updateConfig($data)) {
+        Session::addMessageAfterRedirect(__('Configurações atualizadas com sucesso.', 'agilizepulsar'), true, INFO);
+    } else {
+        Session::addMessageAfterRedirect(__('Não foi possível atualizar as configurações.', 'agilizepulsar'), true, ERROR);
+    }
+
+    Html::redirect($_SERVER['REQUEST_URI']);
+    exit;
+}
+
+$categories = [];
+$category_iterator = $DB->request([
+    'SELECT' => ['id', 'completename'],
+    'FROM'   => 'glpi_itilcategories',
+    'ORDER'  => 'completename'
+]);
+foreach ($category_iterator as $row) {
+    $categories[] = $row;
+}
+
+$profiles = [];
+$profile_iterator = $DB->request([
+    'SELECT' => ['id', 'name'],
+    'FROM'   => 'glpi_profiles',
+    'ORDER'  => 'name'
+]);
+foreach ($profile_iterator as $row) {
+    $profiles[] = $row;
+}
+
+$title = sprintf(__('%s – Configurações', 'agilizepulsar'), $menu_name);
+if (Session::getCurrentInterface() == "helpdesk") {
+   Html::helpHeader($title, '', 'helpdesk', 'management');
+} else {
+   Html::header($title, $_SERVER['PHP_SELF'], 'management', 'pulsar');
+}
+
+$csrf_token = Session::getNewCSRFToken();
+?>
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
+
+<div id="pulsar-demo" class="pulsar-wrap">
+
+  <section class="pulsar-hero card-u">
+    <div class="hero-left">
+      <h1><?php echo htmlspecialchars($menu_name); ?></h1>
+      <p class="pulsar-muted">Configure as categorias e permissões do Pulsar.</p>
+    </div>
+    <div class="pulsar-actions">
+      <a href="feed.php" class="btn-u ghost"><i class="fa-solid fa-arrow-left"></i> Voltar</a>
+    </div>
+  </section>
+
+  <nav class="pulsar-topnav card-u" aria-label="Navegação do Pulsar">
+    <a class="topnav-item" href="feed.php">
+      <i class="fa-solid fa-bolt"></i>
+      <span>Feed</span>
+    </a>
+    <a class="topnav-item" href="my_ideas.php">
+      <i class="fa-solid fa-lightbulb"></i>
+      <span>Minhas Ideias</span>
+    </a>
+    <a class="topnav-item" href="dashboard.php">
+      <i class="fa-solid fa-chart-bar"></i>
+      <span>Dashboard</span>
+    </a>
+    <a class="topnav-item is-active" href="settings.php">
+      <i class="fa-solid fa-gear"></i>
+      <span>Configurações</span>
+    </a>
+  </nav>
+
+  <form method="post" class="settings-form">
+    <input type="hidden" name="_glpi_csrf_token" value="<?php echo $csrf_token; ?>">
+
+    <section class="card-u">
+      <h2><i class="fa-solid fa-sliders"></i> Configurações Gerais</h2>
+      <div class="form-grid">
+        <div class="form-group">
+          <label for="menu_name">Nome do Menu</label>
+          <input type="text" id="menu_name" name="menu_name" value="<?php echo htmlspecialchars($config['menu_name']); ?>" required>
+        </div>
+        <div class="form-group">
+          <label for="campaign_category_id">Categoria de Campanhas</label>
+          <select id="campaign_category_id" name="campaign_category_id" required>
+            <?php foreach ($categories as $category): ?>
+              <option value="<?php echo $category['id']; ?>" <?php echo ($category['id'] == $campaign_category_id) ? 'selected' : ''; ?>>
+                <?php echo htmlspecialchars($category['completename']); ?>
+              </option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="idea_category_id">Categoria de Ideias</label>
+          <select id="idea_category_id" name="idea_category_id" required>
+            <?php foreach ($categories as $category): ?>
+              <option value="<?php echo $category['id']; ?>" <?php echo ($category['id'] == $idea_category_id) ? 'selected' : ''; ?>>
+                <?php echo htmlspecialchars($category['completename']); ?>
+              </option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+      </div>
+    </section>
+
+    <section class="card-u">
+      <h2><i class="fa-solid fa-user-lock"></i> Permissões</h2>
+      <div class="form-grid">
+        <div class="form-group">
+          <label for="view_profile_ids">Perfis que podem visualizar</label>
+          <select id="view_profile_ids" name="view_profile_ids[]" multiple>
+            <?php foreach ($profiles as $profile): ?>
+              <option value="<?php echo $profile['id']; ?>" <?php echo in_array($profile['id'], $view_profiles) ? 'selected' : ''; ?>>
+                <?php echo htmlspecialchars($profile['name']); ?>
+              </option>
+            <?php endforeach; ?>
+          </select>
+          <small class="pulsar-muted">Vazio significa acesso liberado para todos.</small>
+        </div>
+        <div class="form-group">
+          <label for="like_profile_ids">Perfis que podem curtir</label>
+          <select id="like_profile_ids" name="like_profile_ids[]" multiple>
+            <?php foreach ($profiles as $profile): ?>
+              <option value="<?php echo $profile['id']; ?>" <?php echo in_array($profile['id'], $like_profiles) ? 'selected' : ''; ?>>
+                <?php echo htmlspecialchars($profile['name']); ?>
+              </option>
+            <?php endforeach; ?>
+          </select>
+          <small class="pulsar-muted">Vazio significa acesso liberado para todos.</small>
+        </div>
+        <div class="form-group">
+          <label for="admin_profile_ids">Perfis administradores</label>
+          <select id="admin_profile_ids" name="admin_profile_ids[]" multiple>
+            <?php foreach ($profiles as $profile): ?>
+              <option value="<?php echo $profile['id']; ?>" <?php echo in_array($profile['id'], $admin_profiles) ? 'selected' : ''; ?>>
+                <?php echo htmlspecialchars($profile['name']); ?>
+              </option>
+            <?php endforeach; ?>
+          </select>
+          <small class="pulsar-muted">Administradores têm acesso às configurações.</small>
+        </div>
+      </div>
+    </section>
+
+    <div class="form-actions">
+      <button type="submit" class="btn-u primary"><i class="fa-solid fa-floppy-disk"></i> Salvar</button>
+      <a href="feed.php" class="btn-u ghost"><i class="fa-solid fa-xmark"></i> Cancelar</a>
+    </div>
+  </form>
+</div>
+
+<style>
+  .pulsar-wrap *{box-sizing:border-box;margin:0;padding:0}
+  .pulsar-muted{color:#667085}
+  .pulsar-wrap{padding:16px}
+  :root{
+    --u-primary:#00995d;--u-primary-hover:#008552;--u-border:#d1d5db;
+    --u-chip:#e1e1e1;--u-dark:#004e4c;--u-success:#10b981;
+  }
+  .card-u{background:#fff;border:1px solid var(--u-border);border-radius:12px;padding:16px;box-shadow:0 1px 2px rgba(0,0,0,.05);margin-bottom:16px}
+  .pulsar-hero{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:16px;background:linear-gradient(135deg,#f7f7f7 0%,#eef3fb 100%);padding:20px}
+  .pulsar-hero h1{margin:0 0 6px 0;font-size:26px;color:var(--u-dark)}
+  .pulsar-actions{display:flex;gap:12px;flex-wrap:wrap}
+  .btn-u{border:0;border-radius:10px;padding:10px 16px;font-weight:600;cursor:pointer;transition:all .2s;text-decoration:none;display:inline-flex;align-items:center;gap:8px;}
+  .btn-u.primary{background:var(--u-primary);color:#fff}
+  .btn-u.primary:hover{background:var(--u-primary-hover);transform:translateY(-1px);box-shadow:0 2px 4px rgba(0,0,0,.1)}
+  .btn-u.ghost{background:#fff;border:1px solid var(--u-border)}
+  .btn-u.ghost:hover{background:var(--u-chip);border-color:var(--u-primary)}
+  .pulsar-topnav{display:flex;gap:8px;align-items:center;margin-bottom:16px;background:linear-gradient(180deg,#fff,#fbfcff);padding:12px 16px}
+  .topnav-item{display:flex;align-items:center;gap:8px;padding:10px 12px;border-radius:10px;color:#1f2933;text-decoration:none;font-weight:600}
+  .topnav-item.is-active,.topnav-item:hover{background:rgba(0,153,93,.12);color:#00995d}
+  .settings-form{display:flex;flex-direction:column;gap:16px}
+  .form-grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(240px,1fr))}
+  .form-group{display:flex;flex-direction:column;gap:8px}
+  .form-group label{font-weight:600;color:#1f2933}
+  .form-group select,
+  .form-group input{border:1px solid var(--u-border);border-radius:8px;padding:10px;font-size:1rem}
+  .form-group select[multiple]{min-height:160px}
+  .form-actions{display:flex;gap:12px;justify-content:flex-end;padding:8px 0}
+</style>
+<?php
+Html::footer();

--- a/hook.php
+++ b/hook.php
@@ -5,6 +5,42 @@ function plugin_agilizepulsar_install() {
     
     $migration = new Migration(PLUGIN_AGILIZEPULSAR_VERSION);
     
+    if (!$DB->tableExists('glpi_plugin_agilizepulsar_config')) {
+        $query = "CREATE TABLE `glpi_plugin_agilizepulsar_config` (
+            `id` int unsigned NOT NULL AUTO_INCREMENT,
+            `menu_name` varchar(255) DEFAULT 'Pulsar',
+            `campaign_category_id` int unsigned DEFAULT 152,
+            `idea_category_id` int unsigned DEFAULT 153,
+            `view_profile_ids` text,
+            `like_profile_ids` text,
+            `admin_profile_ids` text,
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+        $DB->queryOrDie($query, $DB->error());
+
+        $DB->insertOrDie('glpi_plugin_agilizepulsar_config', [
+            'menu_name'             => 'Pulsar',
+            'campaign_category_id'  => 152,
+            'idea_category_id'      => 153,
+            'view_profile_ids'      => json_encode([]),
+            'like_profile_ids'      => json_encode([]),
+            'admin_profile_ids'     => json_encode([])
+        ]);
+    }
+
+    if (!$DB->tableExists('glpi_plugin_agilizepulsar_views')) {
+        $query = "CREATE TABLE `glpi_plugin_agilizepulsar_views` (
+            `id` int unsigned NOT NULL AUTO_INCREMENT,
+            `tickets_id` int unsigned NOT NULL DEFAULT '0',
+            `users_id` int unsigned NOT NULL DEFAULT '0',
+            `viewed_at` timestamp NULL DEFAULT NULL,
+            PRIMARY KEY (`id`),
+            KEY `tickets_id` (`tickets_id`),
+            KEY `users_id` (`users_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+        $DB->queryOrDie($query, $DB->error());
+    }
+
     if (!$DB->tableExists('glpi_plugin_agilizepulsar_likes')) {
         $query = "CREATE TABLE `glpi_plugin_agilizepulsar_likes` (
             `id` int unsigned NOT NULL AUTO_INCREMENT,
@@ -162,6 +198,8 @@ function plugin_agilizepulsar_uninstall() {
     global $DB;
     
     $tables = [
+        'glpi_plugin_agilizepulsar_config',
+        'glpi_plugin_agilizepulsar_views',
         'glpi_plugin_agilizepulsar_likes',
         'glpi_plugin_agilizepulsar_comments',
         'glpi_plugin_agilizepulsar_approvals',

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1,0 +1,64 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+    die("Sorry. You can't access this file directly");
+}
+
+class PluginAgilizepulsarConfig extends CommonDBTM {
+    static $rightname = 'config';
+
+    public static function getConfig() {
+        global $DB;
+
+        $iterator = $DB->request([
+            'FROM'  => self::getTable(),
+            'LIMIT' => 1
+        ]);
+
+        if (count($iterator) > 0) {
+            return $iterator->current();
+        }
+
+        return [
+            'menu_name'            => 'Pulsar',
+            'campaign_category_id' => 152,
+            'idea_category_id'     => 153,
+            'view_profile_ids'     => json_encode([]),
+            'like_profile_ids'     => json_encode([]),
+            'admin_profile_ids'    => json_encode([])
+        ];
+    }
+
+    public static function updateConfig($data) {
+        $config = new self();
+        $existing = self::getConfig();
+
+        if (isset($existing['id'])) {
+            $data['id'] = $existing['id'];
+            return $config->update($data);
+        }
+
+        return $config->add($data);
+    }
+
+    public static function canView($user_profile_id) {
+        $config  = self::getConfig();
+        $allowed = json_decode($config['view_profile_ids'] ?? '[]', true) ?: [];
+
+        return empty($allowed) || in_array($user_profile_id, $allowed);
+    }
+
+    public static function canLike($user_profile_id) {
+        $config  = self::getConfig();
+        $allowed = json_decode($config['like_profile_ids'] ?? '[]', true) ?: [];
+
+        return empty($allowed) || in_array($user_profile_id, $allowed);
+    }
+
+    public static function canAdmin($user_profile_id) {
+        $config  = self::getConfig();
+        $allowed = json_decode($config['admin_profile_ids'] ?? '[]', true) ?: [];
+
+        return empty($allowed) || in_array($user_profile_id, $allowed);
+    }
+}

--- a/inc/dashboard.class.php
+++ b/inc/dashboard.class.php
@@ -1,0 +1,30 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+    die("Sorry. You can't access this file directly");
+}
+
+class PluginAgilizepulsarDashboard extends CommonGLPI {
+
+    public static function dashboardCards() {
+        $cards = [];
+
+        $cards['plugin_agilizepulsar_stats'] = [
+            'widgettype' => ['bigNumber'],
+            'label'      => __('Estatísticas Pulsar', 'agilizepulsar'),
+            'provider'   => 'PluginAgilizepulsarDashboard::cardStats'
+        ];
+
+        return $cards;
+    }
+
+    public static function cardStats(array $params = []) {
+        $ideas = PluginAgilizepulsarTicket::getIdeas();
+
+        return [
+            'number' => count($ideas),
+            'label'  => sprintf(__('%d ideias ativas', 'agilizepulsar'), count($ideas)),
+            'url'    => Plugin::getWebDir('agilizepulsar') . '/front/feed.php'
+        ];
+    }
+}

--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -7,9 +7,10 @@ if (!defined('GLPI_ROOT')) {
 class PluginAgilizepulsarMenu extends CommonGLPI {
     
     static $rightname = 'ticket';
-    
+
     public static function getMenuName() {
-        return __('Pulsar', 'agilizepulsar');
+        $config = PluginAgilizepulsarConfig::getConfig();
+        return $config['menu_name'];
     }
     
     public static function getMenuContent() {
@@ -38,7 +39,8 @@ class PluginAgilizepulsarMenu extends CommonGLPI {
             'icon' => 'ti ti-chart-bar'
         ];
         
-        if (Session::haveRight('config', UPDATE)) {
+        $profile_id = $_SESSION['glpiactiveprofile']['id'] ?? 0;
+        if (PluginAgilizepulsarConfig::canAdmin($profile_id)) {
             $menu['options']['settings'] = [
                 'title' => __('Configurações', 'agilizepulsar'),
                 'page' => Plugin::getWebDir('agilizepulsar') . '/front/settings.php',

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -5,36 +5,38 @@ if (!defined('GLPI_ROOT')) {
 }
 
 class PluginAgilizepulsarTicket {
-    
-    const CATEGORY_CAMPAIGN = 152;
-    const CATEGORY_IDEA = 153;
-    
+
     public static function isIdea($tickets_id) {
-        global $DB;
-        
+        $config = PluginAgilizepulsarConfig::getConfig();
+        $CATEGORY_IDEA = $config['idea_category_id'];
+
         $ticket = new Ticket();
         if (!$ticket->getFromDB($tickets_id)) {
             return false;
         }
-        
-        return $ticket->fields['itilcategories_id'] == self::CATEGORY_IDEA;
+
+        return $ticket->fields['itilcategories_id'] == $CATEGORY_IDEA;
     }
-    
+
     public static function isCampaign($tickets_id) {
-        global $DB;
-        
+        $config = PluginAgilizepulsarConfig::getConfig();
+        $CATEGORY_CAMPAIGN = $config['campaign_category_id'];
+
         $ticket = new Ticket();
         if (!$ticket->getFromDB($tickets_id)) {
             return false;
         }
-        
-        return $ticket->fields['itilcategories_id'] == self::CATEGORY_CAMPAIGN;
+
+        return $ticket->fields['itilcategories_id'] == $CATEGORY_CAMPAIGN;
     }
-    
+
     public static function getIdeas($filters = []) {
         global $DB;
-        
-        $where = ['itilcategories_id' => self::CATEGORY_IDEA];
+
+        $config = PluginAgilizepulsarConfig::getConfig();
+        $CATEGORY_IDEA = $config['idea_category_id'];
+
+        $where = ['itilcategories_id' => $CATEGORY_IDEA];
         
         if (isset($filters['campaign_id'])) {
             $where['id'] = new QuerySubQuery([
@@ -71,8 +73,11 @@ class PluginAgilizepulsarTicket {
     
     public static function getCampaigns($filters = []) {
         global $DB;
-        
-        $where = ['itilcategories_id' => self::CATEGORY_CAMPAIGN];
+
+        $config = PluginAgilizepulsarConfig::getConfig();
+        $CATEGORY_CAMPAIGN = $config['campaign_category_id'];
+
+        $where = ['itilcategories_id' => $CATEGORY_CAMPAIGN];
         
         if (isset($filters['is_active'])) {
             $where['status'] = [Ticket::INCOMING, Ticket::ASSIGNED, Ticket::PLANNED, Ticket::WAITING];
@@ -94,6 +99,9 @@ class PluginAgilizepulsarTicket {
     
     public static function getIdeasByCampaign($campaign_id) {
         global $DB;
+
+        $config = PluginAgilizepulsarConfig::getConfig();
+        $CATEGORY_IDEA = $config['idea_category_id'];
         
         $iterator = $DB->request([
             'SELECT' => 'tickets_id',
@@ -107,20 +115,21 @@ class PluginAgilizepulsarTicket {
         $ideas = [];
         foreach ($iterator as $data) {
             $ticket = new Ticket();
-            if ($ticket->getFromDB($data['tickets_id']) 
-                && $ticket->fields['itilcategories_id'] == self::CATEGORY_IDEA) {
+            if ($ticket->getFromDB($data['tickets_id'])
+                && $ticket->fields['itilcategories_id'] == $CATEGORY_IDEA) {
                 $ideas[] = self::enrichTicketData($ticket->fields);
             }
         }
-        
+
         return $ideas;
     }
-    
+
     public static function enrichTicketData($ticket_data) {
         $ticket_data['likes_count'] = PluginAgilizepulsarLike::countByTicket($ticket_data['id']);
         $ticket_data['comments_count'] = PluginAgilizepulsarComment::countByTicket($ticket_data['id']);
+        $ticket_data['views_count'] = PluginAgilizepulsarView::countByTicket($ticket_data['id']);
         $ticket_data['has_liked'] = PluginAgilizepulsarLike::userHasLiked($ticket_data['id'], Session::getLoginUserID());
-        
+
         return $ticket_data;
     }
     

--- a/inc/tickettab.class.php
+++ b/inc/tickettab.class.php
@@ -1,0 +1,57 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+    die("Sorry. You can't access this file directly");
+}
+
+class PluginAgilizepulsarTicketTab extends CommonGLPI {
+
+    public static function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
+        if ($item->getType() === 'Ticket') {
+            $config = PluginAgilizepulsarConfig::getConfig();
+            if ($item->fields['itilcategories_id'] == $config['campaign_category_id']
+                || $item->fields['itilcategories_id'] == $config['idea_category_id']) {
+                return $config['menu_name'];
+            }
+        }
+
+        return '';
+    }
+
+    public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0) {
+        if ($item->getType() === 'Ticket') {
+            self::showForTicket($item);
+        }
+        return true;
+    }
+
+    public static function showForTicket(Ticket $ticket) {
+        $tickets_id = $ticket->getID();
+        $likes      = PluginAgilizepulsarLike::getByTicket($tickets_id);
+        $views      = PluginAgilizepulsarView::getByTicket($tickets_id);
+
+        echo "<div class='card-u'>";
+        echo "<h2><i class='fa-solid fa-heart'></i> " . __('Curtidas', 'agilizepulsar') . " (" . count($likes) . ")</h2>";
+        echo "<table class='tab_cadre_fixehov'>";
+        echo "<tr><th>" . __('Usuário', 'agilizepulsar') . "</th><th>" . __('Data', 'agilizepulsar') . "</th></tr>";
+        foreach ($likes as $like) {
+            echo '<tr>';
+            echo '<td>' . htmlspecialchars($like['user_name']) . '</td>';
+            echo '<td>' . Html::convDateTime($like['date_creation']) . '</td>';
+            echo '</tr>';
+        }
+        echo '</table>';
+
+        echo "<h2 style='margin-top:20px'><i class='fa-solid fa-eye'></i> " . __('Visualizações', 'agilizepulsar') . " (" . count($views) . ")</h2>";
+        echo "<table class='tab_cadre_fixehov'>";
+        echo "<tr><th>" . __('Usuário', 'agilizepulsar') . "</th><th>" . __('Data', 'agilizepulsar') . "</th></tr>";
+        foreach ($views as $view) {
+            echo '<tr>';
+            echo '<td>' . htmlspecialchars($view['user_name']) . '</td>';
+            echo '<td>' . Html::convDateTime($view['viewed_at']) . '</td>';
+            echo '</tr>';
+        }
+        echo '</table>';
+        echo '</div>';
+    }
+}

--- a/inc/view.class.php
+++ b/inc/view.class.php
@@ -1,0 +1,73 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+    die("Sorry. You can't access this file directly");
+}
+
+class PluginAgilizepulsarView extends CommonDBTM {
+    static $rightname = 'ticket';
+
+    public static function addView($tickets_id, $users_id) {
+        global $DB;
+
+        if (empty($tickets_id) || empty($users_id)) {
+            return false;
+        }
+
+        $exists = $DB->request([
+            'FROM'  => self::getTable(),
+            'WHERE' => [
+                'tickets_id' => $tickets_id,
+                'users_id'   => $users_id
+            ],
+            'LIMIT' => 1
+        ]);
+
+        if (count($exists) > 0) {
+            return true;
+        }
+
+        $view = new self();
+        return $view->add([
+            'tickets_id' => $tickets_id,
+            'users_id'   => $users_id,
+            'viewed_at'  => $_SESSION['glpi_currenttime'] ?? date('Y-m-d H:i:s')
+        ]);
+    }
+
+    public static function countByTicket($tickets_id) {
+        global $DB;
+
+        $result = $DB->request([
+            'SELECT' => [
+                'views' => new QueryExpression('COUNT(DISTINCT users_id)')
+            ],
+            'FROM'  => self::getTable(),
+            'WHERE' => ['tickets_id' => $tickets_id]
+        ])->current();
+
+        return (int)($result['views'] ?? 0);
+    }
+
+    public static function getByTicket($tickets_id) {
+        global $DB;
+
+        $iterator = $DB->request([
+            'SELECT' => ['users_id', 'viewed_at'],
+            'FROM'   => self::getTable(),
+            'WHERE'  => ['tickets_id' => $tickets_id],
+            'ORDER'  => 'viewed_at DESC'
+        ]);
+
+        $views = [];
+        foreach ($iterator as $data) {
+            $user = new User();
+            if ($user->getFromDB($data['users_id'])) {
+                $data['user_name'] = $user->getFriendlyName();
+                $views[] = $data;
+            }
+        }
+
+        return $views;
+    }
+}

--- a/setup.php
+++ b/setup.php
@@ -9,6 +9,7 @@ function plugin_init_agilizepulsar() {
     
     $PLUGIN_HOOKS['csrf_compliant']['agilizepulsar'] = true;
     
+    Plugin::registerClass('PluginAgilizepulsarConfig');
     Plugin::registerClass('PluginAgilizepulsarMenu');
     Plugin::registerClass('PluginAgilizepulsarTicket');
     Plugin::registerClass('PluginAgilizepulsarLike');
@@ -20,6 +21,9 @@ function plugin_init_agilizepulsar() {
     Plugin::registerClass('PluginAgilizepulsarFastReply');
     Plugin::registerClass('PluginAgilizepulsarApproval');
     Plugin::registerClass('PluginAgilizepulsarLog');
+    Plugin::registerClass('PluginAgilizepulsarView');
+    Plugin::registerClass('PluginAgilizepulsarTicketTab', ['addtabon' => 'Ticket']);
+    Plugin::registerClass('PluginAgilizepulsarDashboard');
     
     $plugin = new Plugin();
     if ($plugin->isInstalled('agilizepulsar') && $plugin->isActivated('agilizepulsar')) {
@@ -30,6 +34,7 @@ function plugin_init_agilizepulsar() {
         
         $PLUGIN_HOOKS['add_css']['agilizepulsar'][] = 'css/pulsar.css';
         $PLUGIN_HOOKS['add_javascript']['agilizepulsar'][] = 'js/pulsar.js';
+        $PLUGIN_HOOKS['dashboard_cards']['agilizepulsar'] = ['PluginAgilizepulsarDashboard', 'dashboardCards'];
     }
 }
 


### PR DESCRIPTION
## Summary
- add persistent configuration storage with profile-based permissions and menu customization
- track idea views with counts surfaced on ideas, dashboards, and ticket tabs
- introduce administrative settings and analytics dashboard pages with filtering and export options

## Testing
- php -l hook.php inc/config.class.php inc/view.class.php inc/tickettab.class.php inc/dashboard.class.php inc/ticket.class.php inc/menu.class.php setup.php front/feed.php front/my_ideas.php front/ideas_all.php front/idea.php front/settings.php front/dashboard.php ajax/like.php

------
https://chatgpt.com/codex/tasks/task_e_68dff020955c8322a6531fc32fb59322