### PR TITLE
Fix points history logging recursion

### DIFF
--- a/inc/pointhistory.class.php
+++ b/inc/pointhistory.class.php
@@ -12,11 +12,13 @@ class PluginAgilizepulsarPointsHistory extends CommonDBTM {
         return __('Points History', 'agilizepulsar');
     }
     
-    public static function add($data) {
+    public static function record(array $data) {
         $history = new self();
-        
-        $data['date_creation'] = $_SESSION['glpi_currenttime'];
-        
+
+        if (!isset($data['date_creation'])) {
+            $data['date_creation'] = $_SESSION['glpi_currenttime'];
+        }
+
         return $history->add($data);
     }
     

--- a/inc/userpoints.class.php
+++ b/inc/userpoints.class.php
@@ -28,7 +28,7 @@ class PluginAgilizepulsarUserPoints extends CommonDBTM {
         
         $userPoints->update($userPoints->fields);
         
-        PluginAgilizepulsarPointsHistory::add([
+        PluginAgilizepulsarPointsHistory::record([
             'users_id' => $users_id,
             'action_type' => $action_type,
             'points_earned' => $config,
@@ -55,7 +55,7 @@ class PluginAgilizepulsarUserPoints extends CommonDBTM {
         
         $userPoints->update($userPoints->fields);
         
-        PluginAgilizepulsarPointsHistory::add([
+        PluginAgilizepulsarPointsHistory::record([
             'users_id' => $users_id,
             'action_type' => 'removed_' . $action_type,
             'points_earned' => -$config,


### PR DESCRIPTION
## Summary
- replace the points history helper with a record method that delegates to the base add implementation and enforces a creation timestamp
- update user point award and removal flows to use the new history helper so inserts succeed

## Testing
- php -l inc/pointhistory.class.php
- php -l inc/userpoints.class.php

------
https://chatgpt.com/codex/tasks/task_e_68e000d34b34832290bc0416462ba58d