### PR TITLE
Allow campaigns in like and comment validation

### DIFF
--- a/ajax/comment.php
+++ b/ajax/comment.php
@@ -15,7 +15,8 @@ $action = $_POST['action'];
 $ticket_id = (int)$_POST['ticket_id'];
 $user_id = Session::getLoginUserID();
 
-if (!PluginAgilizepulsarTicket::isIdea($ticket_id)) {
+if (!PluginAgilizepulsarTicket::isIdea($ticket_id)
+    && !PluginAgilizepulsarTicket::isCampaign($ticket_id)) {
     echo json_encode(['success' => false, 'message' => 'Ticket inválido']);
     exit;
 }

--- a/ajax/like.php
+++ b/ajax/like.php
@@ -21,7 +21,8 @@ $action = $_POST['action'];
 $ticket_id = (int)$_POST['ticket_id'];
 $user_id = Session::getLoginUserID();
 
-if (!PluginAgilizepulsarTicket::isIdea($ticket_id)) {
+if (!PluginAgilizepulsarTicket::isIdea($ticket_id)
+    && !PluginAgilizepulsarTicket::isCampaign($ticket_id)) {
     echo json_encode(['success' => false, 'message' => 'Ticket inválido']);
     exit;
 }


### PR DESCRIPTION
## Summary
- allow campaign tickets to pass the like endpoint validation alongside ideas
- extend the comment endpoint to accept campaign tickets using the same validation rules

## Testing
- php -l ajax/like.php
- php -l ajax/comment.php

------
https://chatgpt.com/codex/tasks/task_e_68e013ba4cc48322935a946730ad0341